### PR TITLE
updated the print to jpeg to be more modular and take an imagefile as…

### DIFF
--- a/nedc_pyprint_image/annotations.py
+++ b/nedc_pyprint_image/annotations.py
@@ -8,20 +8,20 @@ def parse_annotations(file):
     
     # read the data 
     header,data = nadt.read(file)
-
-    # create lists for data
+    
+    # create lists for 
     region_ids = []
     labels = []
     coords = []
-
+    
     # append to the lists
     for i in data:
         region_ids.append(data[i]['region_id'])
-        labels.append(data[i]['region_id'])
+        labels.append(data[i]['text'])
         coords.append(data[i]['coordinates'])
 
     # return the lists
-    return region_ids,labels,coords
+    return header,region_ids,labels,coords
 
 # def main():
 #     filepath = "/data/isip/data/tuh_dpath_breast/deidentified/v2.0.0/svs/train/00707578/s000_2015_04_01/breast/00707578_s000_0hne_0000_a001_lvl000_t000.csv"

--- a/nedc_pyprint_image/classify.py
+++ b/nedc_pyprint_image/classify.py
@@ -13,7 +13,8 @@ def classify_center(imgfile,labelfile,framesize = -1):
     # IDS = list of ints
     # LABELS = list of strings
     # COORDS = list of list of ints
-    IDS,LABELS,COORDS = annotations.parse_annotations(labelfile)
+    # HEADER of file hey Yuan don't worry about the header I made an adjustment in the parsing for something else
+    HEADER,IDS,LABELS,COORDS = annotations.parse_annotations(labelfile)
     NIL = phg.Nil()
     NIL.open(imgfile)
     

--- a/nedc_pyprint_image/creategraphic.py
+++ b/nedc_pyprint_image/creategraphic.py
@@ -1,0 +1,38 @@
+import pointwithin
+import annotations
+import matplotlib.pyplot as plt
+from svstojpg import svs_to_jpg as stj
+import svsdimensions as sd
+def main():
+    filepath = "/data/isip/data/tuh_dpath_breast/deidentified/v2.0.0/svs/train/00707578/s000_2015_04_01/breast/00707578_s000_0hne_0000_a004_lvl000_t000.csv"
+    imagepath = "/data/isip/data/tuh_dpath_breast/deidentified/v2.0.0/svs/train/00707578/s000_2015_04_01/breast/00707578_s000_0hne_0000_a004_lvl000_t000.svs"
+    HEADER,IDS,LABELS,COORDS = annotations.parse_annotations(filepath)
+    
+    
+    w,h = sd.get_dimensions(imagepath)
+    
+    shapes = []
+    coords = []
+    for x in COORDS:
+        for y in x:
+            y.pop()
+            y.reverse()
+
+    x,y = pointwithin.get_border(pointwithin.generate_polygon(COORDS[0]))
+    plt.plot(x,y)
+    for i in range(len(COORDS)):
+        shapes.append(pointwithin.generate_polygon(COORDS[i]))
+        x,y = pointwithin.get_border(shapes[i])
+        plt.plot(x,y)
+        plt.text(COORDS[i][0][0],COORDS[i][0][1],LABELS[i])
+
+    
+    plt.xlim(0,w)
+    plt.ylim(0,h)
+    # stj(imagepath,"./DATA/graphic")
+    im = plt.imread("./DATA/graphic.jpg")
+    plt.imshow(im,extent=[0,w,0,h])
+    plt.savefig("./DATA/demo.png")
+
+
+main()

--- a/nedc_pyprint_image/nedc_pyprint_image.py
+++ b/nedc_pyprint_image/nedc_pyprint_image.py
@@ -41,12 +41,8 @@ def main():
     # prints parsed arguments
     print("imagefilename = ",iname,"labelfilename = ",lname,"fsize = ",fsize,"wsize = ",wsize,"level = ",level,"xoff = ",xoff,"yoff = ",yoff)
 
-    # opens an svs file
-    NIL2 = phg.Nil()
-    NIL2.open(iname)
-
     # printing the image to a jpg
-    winprint.windows_to_jpg(NIL2)
+    winprint.windows_to_jpg(iname)
 
     # closes svs file
     NIL2.close()

--- a/nedc_pyprint_image/pointwithin.py
+++ b/nedc_pyprint_image/pointwithin.py
@@ -18,8 +18,3 @@ def create_grid():
     plt.plot(square_x,square_y)
     plt.plot(amorphous_x,amorphous_y)
     plt.savefig("DATA/demo.png")
-
-def main():
-    create_grid()
-
-main()

--- a/nedc_pyprint_image/printwindows.py
+++ b/nedc_pyprint_image/printwindows.py
@@ -3,7 +3,11 @@ import nedc_image_tools as phg
 import sys
 sys.path.insert(0,"/data/isip/tools/linux_x64/nfc/class/python/nedc_image_tools/nedc_image_tools.py")
 
-def windows_to_jpg(NIL,window_frame=[-1,-1]):
+def windows_to_jpg(imagefile,window_frame=[-1,-1]):
+
+    # open the imagefile
+    NIL = phg.Nil()
+    NIL.open(imagefile)
 
     # Get dimensions
     xdim,ydim =NIL.get_dimension()

--- a/nedc_pyprint_image/svsdimensions.py
+++ b/nedc_pyprint_image/svsdimensions.py
@@ -1,0 +1,8 @@
+import nedc_image_tools as phg
+import sys
+sys.path.insert(0,"/data/isip/tools/linux_x64/nfc/class/python/nedc_image_tools/nedc_image_tools.py")
+
+def get_dimensions(iname):
+    NIL = phg.Nil()
+    NIL.open(iname)
+    return NIL.get_dimension()

--- a/nedc_pyprint_image/svstojpg.py
+++ b/nedc_pyprint_image/svstojpg.py
@@ -1,0 +1,26 @@
+from PIL import Image
+import nedc_image_tools as phg
+import sys
+sys.path.insert(0,"/data/isip/tools/linux_x64/nfc/class/python/nedc_image_tools/nedc_image_tools.py")
+
+def svs_to_jpg(imagefile,name,compress=True):
+
+    NIL = phg.Nil()
+    NIL.open(imagefile)
+
+    # Get dimensions
+    xdim,ydim =NIL.get_dimension()
+
+    # window_frame = [xdim,ydim]
+
+    # Read the single frame
+    windows = NIL.read_data_multithread([[0,0]], xdim, ydim)
+    
+    # save all the images as JPEGS
+    for index, window in enumerate(windows):
+        im = Image.fromarray(window)
+        if compress == True:
+            im=im.resize((xdim//40,ydim//40))
+        im.save(name+'.jpg', "JPEG")
+    
+    return xdim,ydim


### PR DESCRIPTION
… an input

Type in script

I accidentally had it returning region id twice instead of the region id and label names

Added a comment to dictate the functions new use

The function now takes an image file instead of an NIL file type

created a file that return svs dimensions

wanted a helper function for creategraphic.py despite having it in the header from the annotations so this is fully uneccessary

Created script to turn a svs into a compressed jpg

needed a helper function as matplotlib.pyplot.imread can't read files as large as the uncompressed JPEG that PIL.image was producing

Created a script that will create an image that contains the plotted version of what has already been notated

Eventually this function will take cmdl arguments but for now if you change the filepath and imagepath it will create a jpg file of the image and parse the annotations

Afterwards, it creates shapes for each label plots them and overlays them over the iamge that was made. If you want to stop the create of the image just comment and uncomment line 32(stf(imagepath,./DATA/graph) line